### PR TITLE
Create waypoint_tree in tl_detector and make waypoint update frequency configurable

### DIFF
--- a/ros/launch/styx_macos.launch
+++ b/ros/launch/styx_macos.launch
@@ -22,5 +22,5 @@
     <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
 
     <!--Platform Based Params Config -->
-    <param name="params_config" textfile="src/platform/params_config.yaml" />
+    <param name="params_config" textfile="src/platform/params_config_macos.yaml" />
 </launch>

--- a/ros/src/platform/params_config.yaml
+++ b/ros/src/platform/params_config.yaml
@@ -1,0 +1,2 @@
+waypoints_updater:
+  frequency: 50

--- a/ros/src/platform/params_config_macos.yaml
+++ b/ros/src/platform/params_config_macos.yaml
@@ -1,2 +1,2 @@
 waypoints_updater:
-  frequency: 30
+  frequency: 5

--- a/ros/src/platform/params_config_macos.yaml
+++ b/ros/src/platform/params_config_macos.yaml
@@ -1,0 +1,2 @@
+waypoints_updater:
+  frequency: 30

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -85,6 +85,6 @@ class Controller(object):
             decel = max(vel_error, self.decel_limit)
             brake = abs(decel)*self.vehicle_mass*self.wheel_radius # Torque in N*m
         
-        rospy.logwarn("steering Angle is: {0}" . format(steering))
+        # rospy.logwarn("steering Angle is: {0}" . format(steering))
         
         return throttle, brake, steering

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -94,7 +94,7 @@ class WaypointUpdater(object):
             # rospy.logwarn("no red light detected") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data
 
         else:
-            rospy.logwarn("decelerate to 0") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data
+            # rospy.logwarn("decelerate to 0") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data
             lane.waypoints = self.decelerate_waypoints(base_waypoints, closest_idx) # call decelerate_waypoints function to ramp speed to zero
         return lane
             

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -120,7 +120,8 @@ class WaypointUpdater(object):
         self.base_lane = waypoints
         if not self.waypoints_2d:
             self.waypoints_2d = [[waypoint.pose.pose.position.x, waypoint.pose.pose.position.y] for waypoint in waypoints.waypoints]
-            self.waypoint_tree = KDTree(self.waypoints_2d)
+            rospy.loginfo('Constructing waypoint tree')
+            self.waypoint_tree = KDTree(self.waypoints_2d)            
   
     def traffic_cb(self, msg):
         # TODO: Callback for /traffic_waypoint message. Implement

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -5,10 +5,11 @@ from geometry_msgs.msg import PoseStamped
 from std_msgs.msg import Int32
 from styx_msgs.msg import Lane, Waypoint
 from scipy.spatial import KDTree
+import yaml
 
 import math
 MAX_DECEL = 1.0
-FREQUENCY = 10 #50 Hz for Carla, 10Hz for desktop
+FREQUENCY = 30 #50 Hz for Carla, 10Hz for desktop
 LOOKAHEAD_WPS = 200 # Number of waypoints we will publish. You can change this number
 
 
@@ -37,6 +38,9 @@ class WaypointUpdater(object):
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
+        config_string = rospy.get_param("/params_config")
+        self.config = yaml.load(config_string)
+
         # TODO: Add other member variables you need below
         self.pose = None
         self.base_lane = None
@@ -48,7 +52,8 @@ class WaypointUpdater(object):
         self.loop()   # //rospy.spin()
 
     def loop(self):
-        rate = rospy.Rate(FREQUENCY)##updated from 50 to now be variable
+        waypoint_updater_frequency = self.config["waypoints_updater"]["frequency"]
+        rate = rospy.Rate(waypoint_updater_frequency)##updated from 50 to now be variable
         while not rospy.is_shutdown():
             if self.pose and self.base_lane and self.stopline_wp_idx:               # added to ensure three messages are brought in from subscritopns
                 self.publish_waypoints()
@@ -86,7 +91,7 @@ class WaypointUpdater(object):
         
         if self.stopline_wp_idx == -1 or (self.stopline_wp_idx >= farthest_idx):    # if there is no stoplight in range ahead or it is permissive state leave waypoints as is
             lane.waypoints = base_waypoints                                         # populate lane with base_waypoints (don't overwrite base_waypoints)
-            rospy.logwarn("no red light detected") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data
+            # rospy.logwarn("no red light detected") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data
 
         else:
             rospy.logwarn("decelerate to 0") #rospy.logwarn("Filtered Velocity: {0}" .format(self.vel_lpf.get())) # format for data


### PR DESCRIPTION
The changes here ideally would be done in two PRs, but since we're still in the prototyping/experimental phase, I think it's fine to do one PR.

The first change is to parameterize the waypoint update frequency by reading it from config file since it seems like that frequency affects how the simulator runs on different platforms. I added two config files for now, but more can easily be added. I added another entry to the styx*.launch file that points it to the correct config file. For each platform we would need a different styx*.launch file; the default one styx.launch points to a config/yaml file which has frequency set to 50. I created a file for macos styx_macos.launch with entry:
`<!--Platform Based Params Config -->
      <param name="params_config" textfile="src/platform/params_config_macos.yaml" />`.
If you just launch as before `roslaunch launch/styx.launch` it will work as before and use frequency of 50Hz. If you do `roslaunch launch/styx_macos.launch` it will use whatever is in `params_config_macos.yaml`.

The second change is `tl_detector` was failing to process traffic lights because it didn't have `waypoint_tree`, so we're constructing one in function `waypoints_cb`.